### PR TITLE
On off switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A minimal Chrome extension that shows a tooltip when you hover over a link, indi
 - **Visit time:** The tooltip displays how long ago you last visited the link (e.g., "Visited 2 hours, 5 mins ago").
 - **Privacy-friendly:** No data is sent anywhere; all history checks are local.
 - **Chrome-only:** Designed for Google Chrome (Manifest V3).
+- **Enable/disable:** Click the extension icon to temporarily disable or enable the tooltip feature. When disabled, the icon shows an 'OFF' badge and no tooltips will appear.
 
 ## Installation
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -29,7 +29,8 @@ chrome.action.onClicked.addListener(() => {
         chrome.tabs.query({}, (tabs) => {
             for (let tab of tabs) {
                 if (tab.id) {
-                    chrome.tabs.sendMessage(tab.id, { type: 'lvt:set_disabled', disabled });
+                    chrome.tabs.sendMessage(tab.id, { type: 'lvt:set_disabled', disabled })
+                        .catch(() => {}); // Silently ignore if no receiver
                 }
             }
         });

--- a/extension/background.js
+++ b/extension/background.js
@@ -2,6 +2,41 @@
 // Copyright (c) 2025 @thejjw
 
 // Minimal background script for Chrome tooltip extension
+
+// Helper: update badge
+function updateBadge(disabled) {
+    if (disabled) {
+        chrome.action.setBadgeText({ text: 'OFF' });
+        chrome.action.setBadgeBackgroundColor({ color: '#d00' });
+    } else {
+        chrome.action.setBadgeText({ text: '' });
+    }
+}
+
+// On install, set enabled by default
+chrome.runtime.onInstalled.addListener(() => {
+    chrome.storage.local.set({ lvt_disabled: false });
+    updateBadge(false);
+});
+
+// Toggle enabled/disabled on icon click
+chrome.action.onClicked.addListener(() => {
+    chrome.storage.local.get('lvt_disabled', (data) => {
+        const disabled = !data.lvt_disabled;
+        chrome.storage.local.set({ lvt_disabled: disabled });
+        updateBadge(disabled);
+        // Notify all tabs
+        chrome.tabs.query({}, (tabs) => {
+            for (let tab of tabs) {
+                if (tab.id) {
+                    chrome.tabs.sendMessage(tab.id, { type: 'lvt:set_disabled', disabled });
+                }
+            }
+        });
+    });
+});
+
+// Respond to content script queries
 chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse) {
     if (msg.type === "lsr:check_visited") {
         chrome.history.getVisits({ url: msg.url }, function(results) {
@@ -17,4 +52,11 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse) {
         });
         return true; // async
     }
+});
+
+// On startup, set badge state
+chrome.runtime.onStartup.addListener(() => {
+    chrome.storage.local.get('lvt_disabled', (data) => {
+        updateBadge(!!data.lvt_disabled);
+    });
 });

--- a/extension/content.js
+++ b/extension/content.js
@@ -8,8 +8,23 @@ if (typeof browser === "undefined") {
 
 let anchor = null;
 let tooltip_div = null;
+let lvt_disabled = false;
+
+// Listen for enable/disable messages
+browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+    if (msg.type === 'lvt:set_disabled') {
+        lvt_disabled = !!msg.disabled;
+        if (lvt_disabled) hide_tooltip();
+    }
+});
+
+// On load, get disabled state
+browser.storage && browser.storage.local.get('lvt_disabled', (data) => {
+    lvt_disabled = !!data.lvt_disabled;
+});
 
 function show_tooltip(text, x, y) {
+    if (lvt_disabled) return;
     if (!tooltip_div) {
         tooltip_div = document.createElement("div");
         tooltip_div.style.position = "fixed";
@@ -37,6 +52,7 @@ function hide_tooltip() {
 }
 
 document.addEventListener("mouseover", function(e) {
+    if (lvt_disabled) return;
     let a;
     for (a = e.target; a !== null; a = a.parentElement) {
         if (a.tagName === "A" || a.tagName === "AREA") {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -21,6 +21,15 @@
     "background": {
         "service_worker": "background.js"
     },
+    "action": {
+        "default_icon": {
+            "16": "icons/icon16.png",
+            "32": "icons/icon32.png",
+            "48": "icons/icon48.png",
+            "128": "icons/icon128.png"
+        },
+        "default_title": "Click to disable/enable the tooltip"
+    },
     "content_scripts": [
         {
             "matches": ["<all_urls>"],

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Link Visited Tooltip",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Shows a tooltip on link hover indicating when a link was last visited.",
     "author": "@thejjw",
     "icons": {
@@ -11,7 +11,9 @@
         "128": "icons/icon128.png"
     },
     "permissions": [
-        "history"
+        "history",
+        "storage",
+        "tabs"
     ],
     "host_permissions": [
         "<all_urls>"


### PR DESCRIPTION
This pull request introduces a new feature to the Chrome extension, allowing users to enable or disable the tooltip functionality via the extension icon. It also updates the manifest version and permissions to support this functionality. Below is a summary of the most important changes grouped by theme.

### New Feature: Enable/Disable Tooltip

* Updated `README.md` to include instructions for enabling/disabling the tooltip feature via the extension icon. When disabled, the icon displays an 'OFF' badge, and tooltips are suppressed.
* Added logic in `background.js` to toggle the tooltip functionality on icon click, update the badge state, and notify all tabs of the change.
* Enhanced `background.js` to set the badge state on startup based on the stored disabled state.
* Modified `content.js` to listen for enable/disable messages and suppress tooltips when disabled. [[1]](diffhunk://#diff-fdf8b5debf9c89396c9ca4a891fdae30f77d7ad42973678b396e799882537c56R11-R27) [[2]](diffhunk://#diff-fdf8b5debf9c89396c9ca4a891fdae30f77d7ad42973678b396e799882537c56R55)

### Manifest Updates

* Updated `manifest.json` version from `1.0.0` to `1.1.0` to reflect the new feature.
* Added `storage` and `tabs` permissions to `manifest.json` to support the enable/disable functionality. Included an `action` section to define the extension icon's behavior and appearance.