### PR TITLE
Add bookmark feature to link tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ A minimal Chrome extension that shows a tooltip when you hover over a link, indi
 
 ## Features
 
-- **Simple tooltip:** On hovering any link, a small black tooltip appears near the cursor if you have visited the link before.
+- **Simple tooltip:** On hovering any link, a small black tooltip appears near the cursor if you have visited the link before or if it's bookmarked.
 - **Visit time:** The tooltip displays how long ago you last visited the link (e.g., "Visited 2 hours, 5 mins ago").
-- **Privacy-friendly:** No data is sent anywhere; all history checks are local.
+- **Bookmark indicator:** Links that are saved in your bookmarks show a ★ symbol in the tooltip.
+- **Privacy-friendly:** No data is sent anywhere; all history and bookmark checks are local.
 - **Chrome-only:** Designed for Google Chrome (Manifest V3).
 - **Enable/disable:** Click the extension icon to temporarily disable or enable the tooltip feature. When disabled, the icon shows an 'OFF' badge and no tooltips will appear.
 
@@ -17,11 +18,17 @@ A minimal Chrome extension that shows a tooltip when you hover over a link, indi
 3. Enable "Developer mode" (top right).
 4. Click "Load unpacked" and select the `extension` folder.
 
+**Alternatively, install from the [Chrome Web Store](https://chromewebstore.google.com/detail/link-visited-tooltip/eknakfmjakcfjkemkanekcakbnjfkbnc)**  
+_(Note: The Chrome Web Store version may not always have the latest updates.)_
+
 ## Usage
 
 - Hover your mouse over any link on a webpage.
 - If you have visited the link before, a tooltip will appear showing when you last visited it.
-- If you have not visited the link, no tooltip is shown.
+- If the link is bookmarked, a ★ symbol will appear at the beginning of the tooltip.
+- For bookmarked links that haven't been visited, the tooltip shows "★ Bookmarked".
+- For links that are both bookmarked and visited, the tooltip shows "★ Visited X ago".
+- If you have not visited the link and it's not bookmarked, no tooltip is shown.
 
 ## License
 See [LICENSE](LICENSE).

--- a/extension/content.js
+++ b/extension/content.js
@@ -69,6 +69,14 @@ document.addEventListener("mouseover", function(e) {
     }
     browser.runtime.sendMessage({ type: "lsr:check_visited", url: a.href })
         .then(result => {
+            let tooltipText = "";
+            
+            // Add bookmark symbol if bookmarked
+            if (result && result.bookmarked) {
+                tooltipText += "★ ";
+            }
+            
+            // Add visit information if visited
             if (result && result.visited && typeof result.elapsed === "number") {
                 let ago = "";
                 if (result.elapsed < 60) {
@@ -85,7 +93,15 @@ document.addEventListener("mouseover", function(e) {
                     let days = Math.floor(result.elapsed / 86400);
                     ago = `${days} day${days !== 1 ? "s" : ""}`;
                 }
-                show_tooltip(`Visited ${ago} ago`, e.clientX, e.clientY);
+                tooltipText += `Visited ${ago} ago`;
+            } else if (result && result.bookmarked) {
+                // If bookmarked but not visited, just show "Bookmarked"
+                tooltipText += "Bookmarked";
+            }
+            
+            // Show tooltip if we have any information to display
+            if (tooltipText) {
+                show_tooltip(tooltipText, e.clientX, e.clientY);
             } else {
                 hide_tooltip();
             }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -11,6 +11,7 @@
         "128": "icons/icon128.png"
     },
     "permissions": [
+        "bookmarks",
         "history",
         "storage",
         "tabs"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Link Visited Tooltip",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Shows a tooltip on link hover indicating when a link was last visited.",
     "author": "@thejjw",
     "icons": {


### PR DESCRIPTION
Introduce a bookmark indicator in tooltips for links, allowing users to see if a link is bookmarked or visited. Update the extension's documentation and version to reflect these changes.